### PR TITLE
Add cluster name to terraform outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-output "cluster_id" {
-  value = digitalocean_kubernetes_cluster.k8s.id
+output "cluster_name" {
+  value = digitalocean_kubernetes_cluster.k8s.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+
+output "cluster_id" {
+  value = digitalocean_kubernetes_cluster.k8s.id
+}


### PR DESCRIPTION
Cluster name is required when linking module with helm provider.